### PR TITLE
Fix the tab overflow when preview is activated

### DIFF
--- a/src/tab-group.vue
+++ b/src/tab-group.vue
@@ -70,5 +70,8 @@ function onKeyDown(event: KeyboardEvent) {
 	padding: 2px;
 	border-radius: var(--border-radius-outline);
 	background-color: var(--background-subdued);
+	/* I found two solutions, personally I prefer the flex-wrap one */
+	/* overflow: scroll; */
+	flex-wrap: wrap;
 }
 </style>

--- a/src/tab-group.vue
+++ b/src/tab-group.vue
@@ -70,8 +70,6 @@ function onKeyDown(event: KeyboardEvent) {
 	padding: 2px;
 	border-radius: var(--border-radius-outline);
 	background-color: var(--background-subdued);
-	/* I found two solutions, personally I prefer the flex-wrap one */
-	/* overflow: scroll; */
 	flex-wrap: wrap;
 }
 </style>


### PR DESCRIPTION
Hello !

Fix #2.
I found two solutions, I let you use the one you prefer with the UI.

Thank you,
Emilien