### PR TITLE
Add @directus/extensions-sdk as dev dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"release": "semantic-release"
 	},
 	"devDependencies": {
+    "@directus/extensions-sdk": "^10.2.0",
 		"@directus/format-title": "^10.0.0",
 		"@directus/types": "^9.25.3",
 		"@directus/utils": "^9.25.3",


### PR DESCRIPTION
Adds @directus/extensions-sdk" to avoid `yarn build` to fail with:

```
❯ yarn build
yarn run v1.22.19
$ directus-extension build
/bin/sh: line 1: directus-extension: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```