### PR TITLE
Update screenshot preview URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This interface allows you to group fields into tabs as an alternative to
 the default accordion group.
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./docs/screenshot-dark.png">
-  <img alt="Screenshot of the tab group interface" src="./docs/screenshot-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/hanneskuettner/directus-extension-group-tabs-interface/raw/main/docs/screenshot-dark.png">
+  <img alt="Screenshot of the tab group interface" src="https://github.com/hanneskuettner/directus-extension-group-tabs-interface/raw/main/docs/screenshot-light.png">
 </picture>
 
 ## Installation


### PR DESCRIPTION
The screenshot is not displayed in Directus Marketplace. Do you think this should be updated?

![image](https://github.com/user-attachments/assets/5c3d3743-13a4-4003-83ca-65d385ee6e8b)
