### PR TITLE
feat: Add collaborative editing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "directus-extension-group-tabs-interface",
 	"icon": "extension",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"license": "GPL-3.0",
 	"repository": {
 		"type": "git",

--- a/src/group-tabs.vue
+++ b/src/group-tabs.vue
@@ -20,6 +20,7 @@ const props = withDefaults(
 		rawEditorEnabled?: boolean;
 		direction?: string;
 		fillWidth?: boolean;
+		collabContext?: Record<string, unknown>;
 	}>(),
 	{
 		batchActiveFields: () => [],
@@ -107,6 +108,7 @@ function useComputedGroup() {
 				:raw-editor-enabled="rawEditorEnabled"
 				:group="field.meta.field"
 				:direction="direction"
+				:collab-context="collabContext"
 				@apply="$emit('apply', $event)"
 			/>
 		</template>

--- a/src/tab-panel.vue
+++ b/src/tab-panel.vue
@@ -18,6 +18,7 @@ const props = withDefaults(
 		group: string;
 		multiple?: boolean;
 		direction?: string;
+		collabContext?: Record<string, unknown>;
 	}>(),
 	{
 		batchActiveFields: () => [],
@@ -41,6 +42,7 @@ const { fieldsInSection } = useGroupSection(toRefs(props));
 			:batch-mode="batchMode"
 			:disabled="disabled"
 			:direction="direction"
+			:collab-context="collabContext"
 			:show-no-visible-fields="false"
 			:show-validation-errors="false"
 			@update:model-value="$emit('apply', $event)"


### PR DESCRIPTION
## Summary
- Accept `collabContext` prop and pass it through to nested `v-form` components
- Mirrors the pattern used by core group interfaces (`group-detail`, `group-accordion`, `group-raw`)
- Enables presence indicators and field locking inside tab groups

## Details
Directus added collaborative editing with presence indicators. All core group interfaces support this by accepting a `collabContext` prop and forwarding it to `v-form`, which handles field registration and presence tracking internally. This PR adds the same pass-through to the group-tabs interface.

## Test plan
- Install in a Directus instance with collaborative editing enabled
- Open an item with group-tabs fields in two browser sessions
- Verify presence indicators appear on fields inside tabs
- Verify field locking works when another user focuses a field